### PR TITLE
Bump dependencies 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0.1</version>
+      <version>28.1-jre</version>
     </dependency>
 
     <!-- HTTP carrier: Apache HC4x for client transport -->

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.3.5</version>
+      <version>4.5.9</version>
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.sonatype.buildsupport</groupId>
     <artifactId>public-parent</artifactId>
-    <version>6</version>
+    <version>15</version>
   </parent>
 
   <groupId>org.sonatype.spice.zapper</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <hawtbuf.version>1.9</hawtbuf.version>
+    <hawtbuf.version>1.11</hawtbuf.version>
   </properties>
 
   <dependencies>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.7</version>
+      <version>1.7.28</version>
     </dependency>
 
     <!-- Guava -->

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.5</maven.compiler.source>
-    <maven.compiler.target>1.5</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
 
     <hawtbuf.version>1.9</hawtbuf.version>
   </properties>
@@ -113,27 +113,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java15</artifactId>
-            <version>1.0</version>
-          </signature>
-        </configuration>
-        <executions>
-          <execution>
-            <id>check-java-1.5-compat</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <groupId>org.fusesource.hawtbuf</groupId>
         <artifactId>hawtbuf-protoc</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.7.7</version>
+      <version>1.7.28</version>
       <scope>runtime</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>8.1.16.v20140903</version>
+      <version>9.4.20.v20190813</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/sonatype/spice/zapper/AbstractClientTest.java
+++ b/src/test/java/org/sonatype/spice/zapper/AbstractClientTest.java
@@ -28,7 +28,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.eclipse.jetty.server.nio.SelectChannelConnector;
+import org.eclipse.jetty.server.ServerConnector;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -74,7 +74,7 @@ public abstract class AbstractClientTest
   {
     port = getRandomPort();
     server = new Server();
-    SelectChannelConnector connector = new SelectChannelConnector();
+    ServerConnector connector = new ServerConnector(server);
     connector.setPort(port);
     server.addConnector(connector);
 

--- a/src/test/java/org/sonatype/spice/zapper/DeployHandler.java
+++ b/src/test/java/org/sonatype/spice/zapper/DeployHandler.java
@@ -20,7 +20,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.eclipse.jetty.http.HttpMethods;
+import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.server.Dispatcher;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.ContextHandler;
@@ -108,7 +108,7 @@ public class DeployHandler
       return;
     }
 
-    if (HttpMethods.PUT.equals(request.getMethod())) {
+    if (HttpMethod.PUT.is(request.getMethod())) {
       System.out.println("PUT " + request.getRequestURI());
       // let's make client push the content too
       consumeStream(request.getInputStream());


### PR DESCRIPTION
I encountered a `java.lang.NoClassDefFoundError: org/apache/http/conn/HttpClientConnectionManager` when I use `spice-zapper 1.3` with `org.apache.httpcomponents:httpclient:4.5.9`
This PR bump dependencies and minimum JDK to newer hoping to address the above error.